### PR TITLE
Improve cart style and add background color property

### DIFF
--- a/examples/example01.html
+++ b/examples/example01.html
@@ -6,38 +6,34 @@
         <link rel="stylesheet" href="../src/css/seatchart.css">
 
         <style>
+            .content {
+                display: flex;
+                flex-direction: row;
+            }
+
             .right {
-                float: left;
+                display: flex;
+                flex-direction: column;
+                margin-left: 40px;
             }
 
-            .containers {
-                float: left;
-                clear: right;
-                margin-bottom: 20px;
+            #map-container {
+                display: flex;
+                align-items: center;
             }
 
-            .howto {
-                font-family: 'RobotoDraft', 'Roboto', sans-serif;
-                margin-left: 20px;
+            #legend-container {
+                margin-top: 20px;
             }
         </style>
     </head>
     <body>
-        <div id="map-container" class="right"></div>
+        <div class="content">
+            <div id="map-container"></div>
 
-        <div class="right">
-            <div class="containers">
-                <div id="legend-container"  class="right"></div>
-                <div id="shoppingCart-container"  class="right"></div>
-            </div>
-
-            <div class="howto">
-                <h3>HOW TO USE: </h3>
-                <ul>
-                    <li>Right click to select a seat</li>
-                    <li>Left click to unselect a seat</li>
-                    <li>Long press to change seat type</li>
-                </ul>
+            <div class="right">
+                <div id="cart-container"></div>
+                <div id="legend-container"></div>
             </div>
         </div>
 
@@ -59,9 +55,8 @@
             };
 
             var types = [
-                { type: "regular", color: "orange", price: 10, selected: [23, 24] },
-                { type: "reduced", color: "#af0000", price: 7.5, selected: [25, 26] },
-                { type: "military", color: "red", price: 7 }
+                { type: "regular", backgroundColor: "orange", price: 10, selected: [23, 24] },
+                { type: "reduced", backgroundColor: "#ff0000", price: 7.5, selected: [25, 26] }
             ];
 
             var sc = new Seatchart(map, types);
@@ -69,12 +64,12 @@
 
             sc.setAssetsSrc("../src/assets");
             sc.setCurrency(currency);
-            sc.setShoppingCartWidth(200);
-            sc.setShoppingCartHeight(250);
+            sc.setCartWidth(280);
+            sc.setCartHeight(250);
 
             sc.createMap("map-container");
             sc.createLegend("legend-container");
-            sc.createShoppingCart("shoppingCart-container");
+            sc.createCart("cart-container");
         </script>
     </body>
 </html>

--- a/examples/example01.html
+++ b/examples/example01.html
@@ -9,12 +9,14 @@
             .content {
                 display: flex;
                 flex-direction: row;
+                justify-content: center;
+                margin-top: 40px;
             }
 
             .right {
                 display: flex;
                 flex-direction: column;
-                margin-left: 40px;
+                margin-left: 80px;
             }
 
             #map-container {

--- a/src/css/seatchart.css
+++ b/src/css/seatchart.css
@@ -267,7 +267,7 @@
 .sc-ticket {
     display: flex;
     justify-content: center;
-    color: black;
+    color: white;
     font-size: 15px;
     width: 100%;
     height: 30px;

--- a/src/css/seatchart.css
+++ b/src/css/seatchart.css
@@ -174,20 +174,30 @@
 
 /* Shopping cart css */
 
-.sc-cart-items-container {
+.sc-cart-container {
     margin: 15px 0 0;
     padding: 0;
-    border: 1px solid #f3f3f3;
+    border: 1px solid #ddd;
     overflow-y: auto;
     overflow-x: hidden;
 }
 
-.sc-cart-item {
-    border-bottom: 1px solid #afafaf;
+.sc-cart-container table {
+    width: 100%;
+}
+
+.sc-cart-container tr {
+    border-bottom: 1px solid #ddd;
     width: 200px;
-    height: 30px;
     margin: 0 1px 0 0;
     padding: 6px 0 0;
+    height: 40px;
+    min-height: 40px;
+}
+
+.sc-cart-container td {
+    text-align: center;
+    vertical-align: middle;
 }
 
 .sc-cart-delete {
@@ -198,7 +208,7 @@
     background-color: #db2c2c;
 
     /* makes it stay at the right of the container */
-    margin: auto 10px auto auto;
+    margin: auto auto;
     height: 25px;
     width: 25px;
     border-radius: 5px;

--- a/src/css/seatchart.css
+++ b/src/css/seatchart.css
@@ -7,6 +7,7 @@
     -webkit-user-select: none;
     -moz-user-select: none;
     -ms-user-select: none;
+    font-family: Arial, Helvetica, sans-serif;
 }
 
 .sc-container * {

--- a/src/css/seatchart.css
+++ b/src/css/seatchart.css
@@ -17,18 +17,17 @@
 }
 
 .sc-row {
-    height: 46px;
+    display: flex;
 }
 
 .sc-title {
+    display: flex;
+    align-items: center;
     margin: 0;
     padding: 10px 0 0;
 }
 
 .sc-title img {
-    float: left;
-    display: block;
-
     /* ie and edge require height to be set and width to be auto set, not the opposite */
     height: 20px;
     width: auto;
@@ -37,7 +36,6 @@
 }
 
 .sc-title h3 {
-    display: inline-block;
     height: 20px;
     line-height: 20px;
     margin: 0;
@@ -50,6 +48,12 @@
 }
 
 .sc-seat {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 40px;
+    width: 40px;
+    margin: 3px;
     box-sizing: border-box;
     -webkit-box-sizing: border-box;
     -moz-box-sizing: border-box;
@@ -59,44 +63,25 @@
     -webkit-border-top-left-radius: 10px;
     border-top-right-radius: 10px;
     -webkit-border-top-right-radius: 10px;
-    height: 40px;
-    width: 40px;
-    margin: 3px;
-    line-height: 40px;
-    float: left;
-    text-align: center;
-    vertical-align: middle;
 }
 
 .sc-front {
+    display: flex;
+    align-self: center;
+    justify-content: center;
     color: #b0b0b0;
     border-radius: 3px;
     -webkit-border-radius: 3px;
     height: 30px;
     line-height: 30px;
-    margin: 4px;
-    float: left;
     text-align: center;
-    vertical-align: middle;
     background-color: #f5f5f5;
+    width: 100%;
 }
 
 .sc-seat.index {
     background-color: transparent;
     color: #4b4949;
-}
-
-.sc-cart-delete img {
-    height: 15px;
-    width: 15px;
-
-    /* makes img stay centered */
-    position: absolute;
-    margin: auto;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
 }
 
 .sc-seat.blank {
@@ -201,39 +186,33 @@
 }
 
 .sc-cart-delete {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
     cursor: pointer;
-
-    /* makes img stay centered */
-    position: relative;
     background-color: #db2c2c;
-
-    /* makes it stay at the right of the container */
-    margin: auto auto;
     height: 25px;
     width: 25px;
     border-radius: 5px;
     -webkit-border-radius: 5px;
 }
 
-.sc-cart-delete.all {
-    margin: 15px 0 0;
-    padding: 0;
-    width: 60px;
+.sc-cart-delete img {
+    height: 15px;
+    width: 15px;
 }
 
-.sc-cart-delete.all img {
-    right: auto;
-    left: auto;
-    padding-left: 5px;
-    float: left;
+.sc-cart-delete.all {
+    justify-content: flex-start;
+    width: auto;
+    margin-top: 10px;
+    padding: 0 5px;
 }
 
 .sc-cart-delete.all p {
     color: white;
-    text-align: center;
-    line-height: 25px;
     padding: 0;
-    margin: 0 0 0 20px;
+    margin: 0 0 0 5px;
 }
 
 .sc-cart-delete:hover {
@@ -241,7 +220,7 @@
 }
 
 .sc-cart-total {
-    margin: 0;
+    margin: 10px 0 0;
     padding: 0;
     float: right;
     display: block;

--- a/src/css/seatchart.css
+++ b/src/css/seatchart.css
@@ -1,6 +1,6 @@
 /* Seat map css */
 
-.seatChart-container {
+.sc-container {
     display: inline-block;
     cursor: default;
     user-select: none;
@@ -9,18 +9,18 @@
     -ms-user-select: none;
 }
 
-.seatChart-container * {
+.sc-container * {
     box-sizing: content-box;
     -webkit-box-sizing: content-box;
     -moz-box-sizing: content-box;
 }
 
-.seatChart-title {
+.sc-title {
     margin: 0;
     padding: 10px 0 0;
 }
 
-.seatChart-title img {
+.sc-title img {
     float: left;
     display: block;
 
@@ -31,7 +31,7 @@
     padding: 0;
 }
 
-.seatChart-title h3 {
+.sc-title h3 {
     display: inline-block;
     height: 20px;
     line-height: 20px;
@@ -39,12 +39,12 @@
     padding: 0 0 0 10px;
 }
 
-.seatChart-small-title {
+.sc-small-title {
     margin: 0;
     padding: 15px 0 0;
 }
 
-.seatChart-seat {
+.sc-seat {
     box-sizing: border-box;
     -webkit-box-sizing: border-box;
     -moz-box-sizing: border-box;
@@ -63,7 +63,7 @@
     vertical-align: middle;
 }
 
-.seatChart-front {
+.sc-front {
     color: #787878;
     border-radius: 5px;
     -webkit-border-radius: 5px;
@@ -76,12 +76,12 @@
     background-color: #f3f3f3;
 }
 
-.seatChart-seat.index {
+.sc-seat.index {
     background-color: transparent;
     color: #4b4949;
 }
 
-.seatChart-sc-delete img {
+.sc-cart-delete img {
     height: 15px;
     width: 15px;
 
@@ -94,12 +94,12 @@
     right: 0;
 }
 
-.seatChart-seat.blank {
+.sc-seat.blank {
     background-color: transparent;
     color: transparent;
 }
 
-.seatChart-seat.blank img {
+.sc-seat.blank img {
     height: 15px;
     width: auto;
 
@@ -112,49 +112,49 @@
     right: 0;
 }
 
-.seatChart-seat.available {
+.sc-seat.available {
     cursor: pointer;
     background-color: #80c2d1;
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.24);
 }
 
-.seatChart-seat.available:hover {
+.sc-seat.available:hover {
     background-color: #a0d3de;
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06), 0 1px 2px rgba(0, 0, 0, 0.12);
 }
 
-.seatChart-seat.unavailable {
+.sc-seat.unavailable {
     background-color: rgb(210, 210, 210);
     cursor: not-allowed;
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.03), 0 1px 2px rgba(0, 0, 0, 0.06);
 }
 
-.seatChart-seat.clicked {
+.sc-seat.clicked {
     cursor: pointer;
     box-shadow: 0 1px 3px rgba(160, 106, 106, 0.06), 0 1px 2px rgba(0, 0, 0, 0.12);
 }
 
 /* Seat legend css */
 
-.seatChart-legend-list {
+.sc-legend-list {
     list-style-type: none;
     margin: 0;
     padding: 0 0 15px;
 }
 
-.seatChart-legend-item {
+.sc-legend-item {
     margin: 0;
     padding: 15px 0 0;
     vertical-align: middle;
     line-height: 24px;
 }
 
-.seatChart-legend-description {
+.sc-legend-description {
     display: inline-block;
     margin: 0 0 0 10px;
 }
 
-.seatChart-seat.legend-style {
+.sc-seat.legend-style {
     cursor: default;
     float: left;
     width: 23px;
@@ -169,7 +169,7 @@
 
 /* Shopping cart css */
 
-.seatChart-sc-items-container {
+.sc-cart-items-container {
     margin: 15px 0 0;
     padding: 0;
     border: 1px solid #f3f3f3;
@@ -177,7 +177,7 @@
     overflow-x: hidden;
 }
 
-.seatChart-sc-item {
+.sc-cart-item {
     border-bottom: 1px solid #afafaf;
     width: 200px;
     height: 30px;
@@ -185,7 +185,7 @@
     padding: 6px 0 0;
 }
 
-.seatChart-sc-delete {
+.sc-cart-delete {
     cursor: pointer;
 
     /* makes img stay centered */
@@ -200,20 +200,20 @@
     -webkit-border-radius: 5px;
 }
 
-.seatChart-sc-delete.all {
+.sc-cart-delete.all {
     margin: 15px 0 0;
     padding: 0;
     width: 60px;
 }
 
-.seatChart-sc-delete.all img {
+.sc-cart-delete.all img {
     right: auto;
     left: auto;
     padding-left: 5px;
     float: left;
 }
 
-.seatChart-sc-delete.all p {
+.sc-cart-delete.all p {
     color: white;
     text-align: center;
     line-height: 25px;
@@ -221,11 +221,11 @@
     margin: 0 0 0 20px;
 }
 
-.seatChart-sc-delete:hover {
+.sc-cart-delete:hover {
     background-color: #db4646;
 }
 
-.seatChart-sc-total {
+.sc-cart-total {
     margin: 0;
     padding: 0;
     float: right;
@@ -233,7 +233,7 @@
     line-height: 25px;
 }
 
-.seatChart-sc-description {
+.sc-cart-description {
     float: left;
     display: block;
     margin: auto;

--- a/src/css/seatchart.css
+++ b/src/css/seatchart.css
@@ -256,3 +256,42 @@
     font-size: 14px;
     line-height: 25px;
 }
+
+/* Ticket css */
+
+.sc-ticket-container {
+    padding: 5px;
+    width: 150px;
+}
+
+.sc-ticket {
+    display: flex;
+    justify-content: center;
+    color: black;
+    font-size: 15px;
+    width: 100%;
+    height: 30px;
+    border: 2px solid black;
+}
+
+.sc-ticket div {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 100%;
+}
+
+.sc-ticket .sc-cart-seat-name {
+    border-right: 1px dashed black;
+    box-sizing: border-box;
+    width: 30%;
+}
+
+.sc-ticket .sc-cart-seat-type {
+    width: 60%;
+}
+
+.sc-ticket .sc-ticket-stripes {
+    width: 5%;
+    background: repeating-linear-gradient(45deg, black, black 3px, transparent 3px, transparent 6px);
+}

--- a/src/css/seatchart.css
+++ b/src/css/seatchart.css
@@ -16,6 +16,10 @@
     -moz-box-sizing: content-box;
 }
 
+.sc-row {
+    height: 46px;
+}
+
 .sc-title {
     margin: 0;
     padding: 10px 0 0;
@@ -65,16 +69,16 @@
 }
 
 .sc-front {
-    color: #787878;
-    border-radius: 5px;
-    -webkit-border-radius: 5px;
-    height: 40px;
-    line-height: 40px;
+    color: #b0b0b0;
+    border-radius: 3px;
+    -webkit-border-radius: 3px;
+    height: 30px;
+    line-height: 30px;
     margin: 4px;
     float: left;
     text-align: center;
     vertical-align: middle;
-    background-color: #f3f3f3;
+    background-color: #f5f5f5;
 }
 
 .sc-seat.index {

--- a/src/js/seatchart.js
+++ b/src/js/seatchart.js
@@ -2,7 +2,7 @@
  * Creates a seatchart.
  * @constructor
  * @param {Object.<{rows: number, cols: number, reserved: Array.<number>, disabled: Array.<number>, disabledRows: Array.<number>, disabledCols: Array.<number>}>} seatMap - Info to generate the seatmap.
- * @param {Array.<Object.<{type: string, color: string, price: number, selected: Array.<number>}>>} seatTypes - Seat types and their colors to be represented.
+ * @param {Array.<Object.<{type: string, color: string, backgroundColor: string, price: number, selected: Array.<number>}>>} seatTypes - Seat types and their colors to be represented.
  */
 function Seatchart(seatMap, seatTypes) { // eslint-disable-line no-unused-vars
     /**
@@ -88,18 +88,18 @@ function Seatchart(seatMap, seatTypes) { // eslint-disable-line no-unused-vars
         // check if all elements have the needed attribute and contain the right type of value
         for (var i = 0; i < seatTypes.length; i += 1) {
             if (!{}.hasOwnProperty.call(seatTypes[i], 'type') ||
-                !{}.hasOwnProperty.call(seatTypes[i], 'color') ||
+                !{}.hasOwnProperty.call(seatTypes[i], 'backgroundColor') ||
                 !{}.hasOwnProperty.call(seatTypes[i], 'price')) {
                 throw new Error(("Invalid parameter 'seatTypes' supplied to SeatchartJS. " +
                                 "Element at index {0} must contain a 'type', " +
-                                "a 'color' and a 'price' property.").format(i));
+                                "a 'backgroundColor' and a 'price' property.").format(i));
             } else if (!(typeof seatTypes[i].type === 'string' || seatTypes[i].type instanceof String)) {
                 throw new Error(("Invalid parameter 'seatTypes' supplied to SeatchartJS. " +
                                 "'type' property at index {0} must be a string.").format(i));
-            } else if (!(typeof seatTypes[i].color === 'string' ||
-                        seatTypes[i].color instanceof String)) {
+            } else if (!(typeof seatTypes[i].backgroundColor === 'string' ||
+                        seatTypes[i].backgroundColor instanceof String)) {
                 throw new Error(("Invalid parameter 'seatTypes' supplied to SeatchartJS. " +
-                                "'color' property at index {0} must be a string.").format(i));
+                                "'backgroundColor' property at index {0} must be a string.").format(i));
             } else if (typeof seatTypes[i].price !== 'number') {
                 throw new Error(("Invalid parameter 'seatTypes' supplied to SeatchartJS. " +
                                 "'price' property at index {0} must be a number.").format(i));
@@ -108,17 +108,17 @@ function Seatchart(seatMap, seatTypes) { // eslint-disable-line no-unused-vars
     }
 
     /**
-     * Checks if a color is valid and if it's not hexadecimal it's converted.
+     * Checks if background color is valid and if it's not hexadecimal it's converted.
      * @param {string} color - A color (a word or a hexadecimal representation).
      * @returns {string} The hexadecimal representation of the color.
      * @private
      */
     var checkColor = function checkColor(index) {
-        var color = colorToHex(seatTypes[index].color);
+        var color = colorToHex(seatTypes[index].backgroundColor);
 
         if (color.indexOf('#') !== 0) {
             throw new Error(("Invalid parameter 'seatTypes' supplied to SeatchartJS. " +
-                            "'color' property at index {0} must be a valid color. " +
+                            "'backgroundColor' property at index {0} must be a valid color. " +
                             "(e.g. 'red' or '#ff0000', rgb() colors are not accepted)").format(index));
         }
 
@@ -127,7 +127,7 @@ function Seatchart(seatMap, seatTypes) { // eslint-disable-line no-unused-vars
 
     // check the given input
     for (var x = 0; x < seatTypes.length; x += 1) {
-        // check color value
+        // check background color value
         var colorX = checkColor(x);
 
         for (var y = x + 1; y < seatTypes.length; y += 1) {
@@ -138,13 +138,13 @@ function Seatchart(seatMap, seatTypes) { // eslint-disable-line no-unused-vars
                                 'Types are case insensitive.').format(seatTypes[x].type, seatTypes[y].type));
             }
 
-            // check color value
+            // check background color value
             var colorY = checkColor(y);
 
             if (colorX === colorY) {
                 throw new Error(("Invalid parameter 'seatTypes' supplied to SeatchartJS. " +
-                                "'{0}' and '{1}' are equals and colors must be different.")
-                                .format(seatTypes[x].color, seatTypes[y].color));
+                                "'{0}' and '{1}' background colors are equal. They must be different.")
+                                .format(seatTypes[x].backgroundColor, seatTypes[y].backgroundColor));
             }
         }
     }
@@ -563,11 +563,14 @@ function Seatchart(seatMap, seatTypes) { // eslint-disable-line no-unused-vars
      * @private
      */
     var createTicket = function createTicker(seat) {
+        var seatConfig = seatTypes.find(function findSeatType(x) {
+            return x.type === seat.type;
+        });
+
         var ticket = document.createElement('div');
         ticket.className = 'sc-ticket';
-        ticket.style.backgroundColor = seatTypes.find(function findSeatType(x) {
-            return x.type === seat.type;
-        }).color;
+        ticket.style.color = seatConfig.color;
+        ticket.style.backgroundColor = seatConfig.backgroundColor;
 
         var stripes = document.createElement('div');
         stripes.className = 'sc-ticket-stripes';
@@ -674,10 +677,13 @@ function Seatchart(seatMap, seatTypes) { // eslint-disable-line no-unused-vars
             cartItem = document.getElementById('item-{0}'.format(id));
             var itemContent = cartItem.getElementsByTagName('td');
 
-            var ticket = itemContent[0].getElementsByClassName('sc-ticket')[0];
-            ticket.style.backgroundColor = seatTypes.find(function findSeatType(x) {
+            var seatConfig = seatTypes.find(function findSeatType(x) {
                 return x.type === current.type;
-            }).color;
+            });
+
+            var ticket = itemContent[0].getElementsByClassName('sc-ticket')[0];
+            ticket.style.backgroundColor = seatConfig.backgroundColor;
+            ticket.style.color = seatConfig.color;
 
             var ticketType = ticket.getElementsByClassName('sc-cart-seat-type')[0];
             ticketType.textContent = current.type.capitalizeFirstLetter();
@@ -761,6 +767,7 @@ function Seatchart(seatMap, seatTypes) { // eslint-disable-line no-unused-vars
                     newClass = types[index];
 
                     this.style.backgroundColor = '';
+                    this.style.color = '';
                     this.classList.add(newClass);
 
                     // if the class isn't available then apply the background-color in the config
@@ -773,7 +780,8 @@ function Seatchart(seatMap, seatTypes) { // eslint-disable-line no-unused-vars
                         }
 
                         this.classList.add('clicked');
-                        this.style.backgroundColor = seatTypes[index].color;
+                        this.style.backgroundColor = seatTypes[index].backgroundColor;
+                        this.style.color = seatTypes[index].color;
                     } else {
                         // otherwise remove the class 'clicked'
                         // since available has it's own style
@@ -1000,6 +1008,7 @@ function Seatchart(seatMap, seatTypes) { // eslint-disable-line no-unused-vars
 
             if ({}.hasOwnProperty.call(seatType, 'selected') && seatType.selected) {
                 var type = seatType.type;
+                var backgroundColor = seatType.backgroundColor;
                 var color = seatType.color;
 
                 for (var l = 0; l < seatType.selected.length; l += 1) {
@@ -1012,7 +1021,8 @@ function Seatchart(seatMap, seatTypes) { // eslint-disable-line no-unused-vars
                         element.classList.remove('available');
                         element.classList.add(type);
                         element.classList.add('clicked');
-                        element.style.backgroundColor = color;
+                        element.style.backgroundColor = backgroundColor;
+                        element.style.color = color;
                     }
                 }
             }
@@ -1310,7 +1320,8 @@ function Seatchart(seatMap, seatTypes) { // eslint-disable-line no-unused-vars
             if (type !== 'available' && type !== 'disabled' && type !== 'reserved') {
                 if (removeFromCartDict(seat.id, seat.type) && addToCartDict(seat.id, type)) {
                     element.classList.add('clicked');
-                    element.style.setProperty('background-color', seatType.color);
+                    element.style.setProperty('background-color', seatType.backgroundColor);
+                    element.style.setProperty('color', seatType.color);
                     updateCart('update', seat.id, type, seat.type, emit);
                 }
             } else if (removeFromCartDict(seat.id, seat.type)) {
@@ -1321,7 +1332,8 @@ function Seatchart(seatMap, seatTypes) { // eslint-disable-line no-unused-vars
         } else if (type !== 'available' && type !== 'disabled' && type !== 'reserved') {
             if (addToCartDict(seat.id, type)) {
                 element.classList.add('clicked');
-                element.style.setProperty('background-color', seatType.color);
+                element.style.setProperty('background-color', seatType.backgroundColor);
+                element.style.setProperty('color', seatType.color);
                 updateCart('add', seat.id, type, seat.type, emit);
             }
         }
@@ -1422,14 +1434,14 @@ function Seatchart(seatMap, seatTypes) { // eslint-disable-line no-unused-vars
     };
 
     /**
-     * Creates a legend item and applies a type and a color if needed.
+     * Creates a legend item and applies a type and a backgroundColor if needed.
      * @param {string} content - The text in the legend that explains the type of seat.
      * @param {string} type - The type of seat.
-     * @param {string} color - The background color of the item in the legend.
+     * @param {string} backgroundColor - The background color of the item in the legend.
      * @returns {HTMLListItemElement} The legend item.
      * @private
      */
-    var createLegendItem = function createLegendItem(content, type, color) {
+    var createLegendItem = function createLegendItem(content, type, backgroundColor) {
         var item = document.createElement('li');
         item.className = 'sc-legend-item';
         var itemStyle = document.createElement('div');
@@ -1438,9 +1450,9 @@ function Seatchart(seatMap, seatTypes) { // eslint-disable-line no-unused-vars
         description.className = 'sc-legend-description';
         description.textContent = content;
 
-        if (color !== undefined) {
+        if (backgroundColor !== undefined) {
             itemStyle.className = '{0} clicked'.format(itemStyle.className);
-            itemStyle.style.backgroundColor = color;
+            itemStyle.style.backgroundColor = backgroundColor;
         }
 
         item.appendChild(itemStyle);
@@ -1493,7 +1505,7 @@ function Seatchart(seatMap, seatTypes) { // eslint-disable-line no-unused-vars
                 self.currency,
                 seatTypes[i].price.toFixed(2)
             );
-            var item = createLegendItem(description, '', seatTypes[i].color);
+            var item = createLegendItem(description, '', seatTypes[i].backgroundColor);
             seatsList.appendChild(item);
         }
         seatsList.appendChild(createLegendItem('Already booked', 'unavailable'));

--- a/src/js/seatchart.js
+++ b/src/js/seatchart.js
@@ -45,22 +45,6 @@ function Seatchart(seatMap, seatTypes) { // eslint-disable-line no-unused-vars
         return el.currentStyle;
     };
 
-    /**
-     * Converts a color to its equivalent in hexadecimal.
-     * @param {string} color - A color (e.g. "#00ffff", "blue").
-     * @returns {string} Hexadeciaml representation of the color.
-     * @private
-     */
-    function colorToHex(color) {
-        /* eslint-disable */
-        var colors = {'aliceblue':'#f0f8ff','antiquewhite':'#faebd7','aqua':'#00ffff','aquamarine':'#7fffd4','azure':'#f0ffff','beige':'#f5f5dc','bisque':'#ffe4c4','black':'#000000','blanchedalmond':'#ffebcd','blue':'#0000ff','blueviolet':'#8a2be2','brown':'#a52a2a','burlywood':'#deb887','cadetblue':'#5f9ea0','chartreuse':'#7fff00','chocolate':'#d2691e','coral':'#ff7f50','cornflowerblue':'#6495ed','cornsilk':'#fff8dc','crimson':'#dc143c','cyan':'#00ffff','darkblue':'#00008b','darkcyan':'#008b8b','darkgoldenrod':'#b8860b','darkgray':'#a9a9a9','darkgreen':'#006400','darkkhaki':'#bdb76b','darkmagenta':'#8b008b','darkolivegreen':'#556b2f','darkorange':'#ff8c00','darkorchid':'#9932cc','darkred':'#8b0000','darksalmon':'#e9967a','darkseagreen':'#8fbc8f','darkslateblue':'#483d8b','darkslategray':'#2f4f4f','darkturquoise':'#00ced1','darkviolet':'#9400d3','deeppink':'#ff1493','deepskyblue':'#00bfff','dimgray':'#696969','dodgerblue':'#1e90ff','firebrick':'#b22222','floralwhite':'#fffaf0','forestgreen':'#228b22','fuchsia':'#ff00ff','gainsboro':'#dcdcdc','ghostwhite':'#f8f8ff','gold':'#ffd700','goldenrod':'#daa520','gray':'#808080','green':'#008000','greenyellow':'#adff2f','honeydew':'#f0fff0','hotpink':'#ff69b4','indianred ':'#cd5c5c','indigo':'#4b0082','ivory':'#fffff0','khaki':'#f0e68c','lavender':'#e6e6fa','lavenderblush':'#fff0f5','lawngreen':'#7cfc00','lemonchiffon':'#fffacd','lightblue':'#add8e6','lightcoral':'#f08080','lightcyan':'#e0ffff','lightgoldenrodyellow':'#fafad2','lightgrey':'#d3d3d3','lightgreen':'#90ee90','lightpink':'#ffb6c1','lightsalmon':'#ffa07a','lightseagreen':'#20b2aa','lightskyblue':'#87cefa','lightslategray':'#778899','lightsteelblue':'#b0c4de','lightyellow':'#ffffe0','lime':'#00ff00','limegreen':'#32cd32','linen':'#faf0e6','magenta':'#ff00ff','maroon':'#800000','mediumaquamarine':'#66cdaa','mediumblue':'#0000cd','mediumorchid':'#ba55d3','mediumpurple':'#9370d8','mediumseagreen':'#3cb371','mediumslateblue':'#7b68ee','mediumspringgreen':'#00fa9a','mediumturquoise':'#48d1cc','mediumvioletred':'#c71585','midnightblue':'#191970','mintcream':'#f5fffa','mistyrose':'#ffe4e1','moccasin':'#ffe4b5','navajowhite':'#ffdead','navy':'#000080','oldlace':'#fdf5e6','olive':'#808000','olivedrab':'#6b8e23','orange':'#ffa500','orangered':'#ff4500','orchid':'#da70d6','palegoldenrod':'#eee8aa','palegreen':'#98fb98','paleturquoise':'#afeeee','palevioletred':'#d87093','papayawhip':'#ffefd5','peachpuff':'#ffdab9','peru':'#cd853f','pink':'#ffc0cb','plum':'#dda0dd','powderblue':'#b0e0e6','purple':'#800080','red':'#ff0000','rosybrown':'#bc8f8f','royalblue':'#4169e1','saddlebrown':'#8b4513','salmon':'#fa8072','sandybrown':'#f4a460','seagreen':'#2e8b57','seashell':'#fff5ee','sienna':'#a0522d','silver':'#c0c0c0','skyblue':'#87ceeb','slateblue':'#6a5acd','slategray':'#708090','snow':'#fffafa','springgreen':'#00ff7f','steelblue':'#4682b4','tan':'#d2b48c','teal':'#008080','thistle':'#d8bfd8','tomato':'#ff6347','turquoise':'#40e0d0','violet':'#ee82ee','wheat':'#f5deb3','white':'#ffffff','whitesmoke':'#f5f5f5','yellow':'#ffff00','yellowgreen':'#9acd32'};
-        /* eslint-enable */
-
-        var hex = colors[color.toLowerCase()];
-
-        return typeof hex !== 'undefined' ? hex : color;
-    }
-
     // check seatMap parameter
     if (seatMap === undefined) {
         throw new Error("Invalid parameter 'seatMap' supplied to SeatchartJS. Cannot be undefined.");
@@ -107,44 +91,14 @@ function Seatchart(seatMap, seatTypes) { // eslint-disable-line no-unused-vars
         }
     }
 
-    /**
-     * Checks if background color is valid and if it's not hexadecimal it's converted.
-     * @param {string} color - A color (a word or a hexadecimal representation).
-     * @returns {string} The hexadecimal representation of the color.
-     * @private
-     */
-    var checkColor = function checkColor(index) {
-        var color = colorToHex(seatTypes[index].backgroundColor);
-
-        if (color.indexOf('#') !== 0) {
-            throw new Error(("Invalid parameter 'seatTypes' supplied to SeatchartJS. " +
-                            "'backgroundColor' property at index {0} must be a valid color. " +
-                            "(e.g. 'red' or '#ff0000', rgb() colors are not accepted)").format(index));
-        }
-
-        return color;
-    };
-
     // check the given input
     for (var x = 0; x < seatTypes.length; x += 1) {
-        // check background color value
-        var colorX = checkColor(x);
-
         for (var y = x + 1; y < seatTypes.length; y += 1) {
             if (seatTypes[x].type.capitalizeFirstLetter() ===
                 seatTypes[y].type.capitalizeFirstLetter()) {
                 throw new Error(("Invalid parameter 'seatTypes' supplied to SeatchartJS. " +
-                                "'{0}' and '{1}' are equals and types must be different. " +
+                                "'{0}' and '{1}' types are equal and must be different. " +
                                 'Types are case insensitive.').format(seatTypes[x].type, seatTypes[y].type));
-            }
-
-            // check background color value
-            var colorY = checkColor(y);
-
-            if (colorX === colorY) {
-                throw new Error(("Invalid parameter 'seatTypes' supplied to SeatchartJS. " +
-                                "'{0}' and '{1}' background colors are equal. They must be different.")
-                                .format(seatTypes[x].backgroundColor, seatTypes[y].backgroundColor));
             }
         }
     }

--- a/src/js/seatchart.js
+++ b/src/js/seatchart.js
@@ -532,7 +532,7 @@ function Seatchart(seatMap, seatTypes) { // eslint-disable-line no-unused-vars
      */
     var updateTotal = function updateTotal() {
         if (cartTotal !== undefined) {
-            cartTotal.textContent = 'Total: {0}{1}'.format(self.getTotal(), self.currency);
+            cartTotal.textContent = 'Total: {0}{1}'.format(self.currency, self.getTotal());
         }
     };
 

--- a/src/js/seatchart.js
+++ b/src/js/seatchart.js
@@ -532,7 +532,7 @@ function Seatchart(seatMap, seatTypes) { // eslint-disable-line no-unused-vars
      */
     var updateTotal = function updateTotal() {
         if (cartTotal !== undefined) {
-            cartTotal.textContent = 'Total: {0}{1}'.format(self.currency, self.getTotal());
+            cartTotal.textContent = 'Total: {0}{1}'.format(self.currency, self.getTotal().toFixed(2));
         }
     };
 
@@ -591,7 +591,7 @@ function Seatchart(seatMap, seatTypes) { // eslint-disable-line no-unused-vars
         seatType.textContent = seat.type.capitalizeFirstLetter();
 
         var seatPrice = document.createElement('td');
-        seatPrice.textContent = '{0}{1}'.format(self.currency, seat.price);
+        seatPrice.textContent = '{0}{1}'.format(self.currency, seat.price.toFixed(2));
 
         var deleteTd = document.createElement('td');
         var deleteBtn = createScDeleteButton();
@@ -638,7 +638,12 @@ function Seatchart(seatMap, seatTypes) { // eslint-disable-line no-unused-vars
         };
 
         var scItem;
-        var description = '{0} - {1} {2}{3}\n'.format(seatName, type.capitalizeFirstLetter(), self.currency, price);
+        var description = '{0} - {1} {2}{3}\n'.format(
+            seatName,
+            type.capitalizeFirstLetter(),
+            self.currency,
+            price.toFixed(2)
+        );
 
         updateCartObject();
 
@@ -1464,7 +1469,7 @@ function Seatchart(seatMap, seatTypes) { // eslint-disable-line no-unused-vars
             var description = '{0} {1}{2}'.format(
                 seatTypes[i].type.capitalizeFirstLetter(),
                 self.currency,
-                seatTypes[i].price
+                seatTypes[i].price.toFixed(2)
             );
             var item = createLegendItem(description, '', seatTypes[i].color);
             seatsList.appendChild(item);

--- a/src/js/seatchart.js
+++ b/src/js/seatchart.js
@@ -632,7 +632,7 @@ function Seatchart(seatMap, seatTypes) { // eslint-disable-line no-unused-vars
         };
 
         var scItem;
-        var description = '{0} - {1} {2}{3}\n'.format(seatName, type.capitalizeFirstLetter(), price, self.currency);
+        var description = '{0} - {1} {2}{3}\n'.format(seatName, type.capitalizeFirstLetter(), self.currency, price);
 
         updateShoppingCartObject();
 
@@ -945,7 +945,7 @@ function Seatchart(seatMap, seatTypes) { // eslint-disable-line no-unused-vars
                     var id = '{0}_{1}'.format(row, column);
                     var seatName = '{0}{1}'.format(alphabet[row], column + 1);
                     var capitalizedType = type.capitalizeFirstLetter();
-                    var description = '{0} - {1} {2}{3}\n'.format(seatName, capitalizedType, price, self.currency);
+                    var description = '{0} - {1} {2}{3}\n'.format(seatName, capitalizedType, self.currency, price);
 
                     var scItem = createScItem(description, id);
                     scItemsContainer.appendChild(scItem);
@@ -1454,8 +1454,8 @@ function Seatchart(seatMap, seatTypes) { // eslint-disable-line no-unused-vars
         for (var i = 0; i < seatTypes.length; i += 1) {
             var description = '{0} {1}{2}'.format(
                 seatTypes[i].type.capitalizeFirstLetter(),
-                seatTypes[i].price,
-                self.currency
+                self.currency,
+                seatTypes[i].price
             );
             var item = createLegendItem(description, '', seatTypes[i].color);
             seatsList.appendChild(item);
@@ -1545,7 +1545,7 @@ function Seatchart(seatMap, seatTypes) { // eslint-disable-line no-unused-vars
     var createScTotal = function createScTotal() {
         var container = document.createElement('div');
 
-        shoppingCartTotal = createSmallTitle('Total: {0}{1}'.format(self.getTotal(), self.currency));
+        shoppingCartTotal = createSmallTitle('Total: {0}{1}'.format(self.currency, self.getTotal()));
         shoppingCartTotal.className += ' sc-cart-total';
 
         var deleteBtn = createScDeleteButton();
@@ -1569,7 +1569,7 @@ function Seatchart(seatMap, seatTypes) { // eslint-disable-line no-unused-vars
     this.createShoppingCart = function createShoppingCart(containerId) {
         var shoppingCartContainer = createContainer();
         var shoppingCartTitle = createIconedTitle(
-            'Shopping cart',
+            'Your Cart',
             '{0}/icons/shoppingcart.svg'.format(self.assetsSrc),
             'Shopping cart icon.'
         );

--- a/src/js/seatchart.js
+++ b/src/js/seatchart.js
@@ -637,13 +637,7 @@ function Seatchart(seatMap, seatTypes) { // eslint-disable-line no-unused-vars
             price: ['available', 'disabled', 'reserved'].indexOf(previousType) < 0 ? self.getPrice(previousType) : null
         };
 
-        var scItem;
-        var description = '{0} - {1} {2}{3}\n'.format(
-            seatName,
-            type.capitalizeFirstLetter(),
-            self.currency,
-            price.toFixed(2)
-        );
+        var cartItem;
 
         updateCartObject();
 
@@ -657,17 +651,18 @@ function Seatchart(seatMap, seatTypes) { // eslint-disable-line no-unused-vars
             }
         } else if (action === 'add') {
             if (cartTable !== undefined) {
-                scItem = createCartItem(current);
-                cartTable.appendChild(scItem);
+                cartItem = createCartItem(current);
+                cartTable.appendChild(cartItem);
             }
 
             if (emit && self.onChange !== null) {
                 self.onChange(action, current, previous);
             }
         } else if (action === 'update') {
-            scItem = document.getElementById('item-{0}'.format(id));
-            var p = scItem.getElementsByTagName('p')[0];
-            p.textContent = description;
+            cartItem = document.getElementById('item-{0}'.format(id));
+            var itemContent = cartItem.getElementsByTagName('td');
+            itemContent[1].textContent = current.type.capitalizeFirstLetter();
+            itemContent[2].textContent = '{0}{1}'.format(self.currency, current.price.toFixed(2));
 
             if (emit && self.onChange !== null) {
                 self.onChange(action, current, previous);
@@ -961,8 +956,8 @@ function Seatchart(seatMap, seatTypes) { // eslint-disable-line no-unused-vars
                         type: type,
                         price: price
                     };
-                    var scItem = createCartItem(seat);
-                    cartTable.appendChild(scItem);
+                    var cartItem = createCartItem(seat);
+                    cartTable.appendChild(cartItem);
                 }
             }
         }

--- a/src/js/seatchart.js
+++ b/src/js/seatchart.js
@@ -1360,7 +1360,7 @@ function Seatchart(seatMap, seatTypes) { // eslint-disable-line no-unused-vars
                                        margins);
 
         var front = seatMapContainer.getElementsByClassName('sc-front')[0];
-        front.style.width = '{0}px'.format(((width + margins) * seatMap.cols) - margins);
+        front.style.width = '{0}px'.format((width + margins) * seatMap.cols);
 
         // add disabled columns to disabled array
         if (seatMap.disabledCols) {

--- a/src/js/seatchart.js
+++ b/src/js/seatchart.js
@@ -451,7 +451,7 @@ function Seatchart(seatMap, seatTypes) { // eslint-disable-line no-unused-vars
         binImg.src = '{0}/icons/bin.svg'.format(self.assetsSrc);
 
         var deleteBtn = document.createElement('div');
-        deleteBtn.className = 'seatChart-sc-delete';
+        deleteBtn.className = 'sc-cart-delete';
         deleteBtn.appendChild(binImg);
 
         return deleteBtn;
@@ -494,7 +494,7 @@ function Seatchart(seatMap, seatTypes) { // eslint-disable-line no-unused-vars
     var releaseSeat = function releaseSeat(id) {
         var seat = document.getElementById(id);
         seat.style.cssText = '';
-        seat.className = 'seatChart-seat available';
+        seat.className = 'sc-seat available';
     };
 
     /**
@@ -584,13 +584,13 @@ function Seatchart(seatMap, seatTypes) { // eslint-disable-line no-unused-vars
      */
     var createScItem = function createScItem(description, id) {
         var item = document.createElement('div');
-        item.className = 'seatChart-sc-item';
+        item.className = 'sc-cart-item';
         // -2 because of the item left padding
         item.style.width = '{0}px'.format(self.shoppingCartWidth - getScrollBarWidth() - 2);
         item.setAttribute('id', 'item-{0}'.format(id));
 
         var desc = document.createElement('p');
-        desc.className = 'seatChart-sc-description';
+        desc.className = 'sc-cart-description';
         desc.textContent = description;
 
         var deleteBtn = createScDeleteButton();
@@ -673,7 +673,7 @@ function Seatchart(seatMap, seatTypes) { // eslint-disable-line no-unused-vars
     var createTitle = function createTitle(content) {
         var title = document.createElement('h3');
         title.textContent = content;
-        title.className = 'seatChart-title';
+        title.className = 'sc-title';
 
         return title;
     };
@@ -717,7 +717,7 @@ function Seatchart(seatMap, seatTypes) { // eslint-disable-line no-unused-vars
             var currentClass = currentClassList[i];
             var newClass;
 
-            if (currentClass !== 'seatChart-seat' && currentClass !== 'clicked') {
+            if (currentClass !== 'sc-seat' && currentClass !== 'clicked') {
                 // find index of current
                 var index = types.indexOf(currentClass);
 
@@ -810,7 +810,7 @@ function Seatchart(seatMap, seatTypes) { // eslint-disable-line no-unused-vars
     var createSeat = function createSeat(type, content, seatId) {
         var seat = document.createElement('div');
         seat.textContent = content;
-        seat.className = 'seatChart-seat ' + type;
+        seat.className = 'sc-seat ' + type;
 
         // if seatId wasn't passed as argument then don't set it
         if (seatId !== undefined) {
@@ -832,7 +832,7 @@ function Seatchart(seatMap, seatTypes) { // eslint-disable-line no-unused-vars
      */
     var createRow = function createRow(rowIndex) {
         var row = document.createElement('div');
-        row.className = 'seatChart-row';
+        row.className = 'sc-row';
 
         if (rowIndex === undefined) {
             row.appendChild(createSeat('blank', ''));
@@ -854,7 +854,7 @@ function Seatchart(seatMap, seatTypes) { // eslint-disable-line no-unused-vars
         // set the perfect width of the front indicator
         var front = document.createElement('div');
         front.textContent = 'Front';
-        front.className = 'seatChart-front';
+        front.className = 'sc-front';
         header.appendChild(front);
 
         return header;
@@ -882,7 +882,7 @@ function Seatchart(seatMap, seatTypes) { // eslint-disable-line no-unused-vars
      */
     var createContainer = function createContainer() {
         var container = document.createElement('div');
-        container.className = 'seatChart-container';
+        container.className = 'sc-container';
 
         return container;
     };
@@ -1345,7 +1345,7 @@ function Seatchart(seatMap, seatTypes) { // eslint-disable-line no-unused-vars
         container.appendChild(seatMapContainer);
 
         // set front indicator
-        var seat = document.getElementsByClassName('seatChart-seat')[0];
+        var seat = document.getElementsByClassName('sc-seat')[0];
         var width = seat.offsetWidth;
 
         var computedStyle = getStyle(seat);
@@ -1357,7 +1357,7 @@ function Seatchart(seatMap, seatTypes) { // eslint-disable-line no-unused-vars
         seatMapContainer.style.width = '{0}px'.format(((width + margins) * (seatMap.cols + 1)) +
                                        margins);
 
-        var front = seatMapContainer.getElementsByClassName('seatChart-front')[0];
+        var front = seatMapContainer.getElementsByClassName('sc-front')[0];
         front.style.width = '{0}px'.format(((width + margins) * seatMap.cols) - margins);
 
         // add disabled columns to disabled array
@@ -1395,11 +1395,11 @@ function Seatchart(seatMap, seatTypes) { // eslint-disable-line no-unused-vars
      */
     var createLegendItem = function createLegendItem(content, type, color) {
         var item = document.createElement('li');
-        item.className = 'seatChart-legend-item';
+        item.className = 'sc-legend-item';
         var itemStyle = document.createElement('div');
-        itemStyle.className = 'seatChart-seat legend-style {0}'.format(type);
+        itemStyle.className = 'sc-seat legend-style {0}'.format(type);
         var description = document.createElement('p');
-        description.className = 'seatChart-legend-description';
+        description.className = 'sc-legend-description';
         description.textContent = content;
 
         if (color !== undefined) {
@@ -1420,7 +1420,7 @@ function Seatchart(seatMap, seatTypes) { // eslint-disable-line no-unused-vars
      */
     var createLegendList = function createLegendList() {
         var list = document.createElement('ul');
-        list.className = 'seatChart-legend-list';
+        list.className = 'sc-legend-list';
 
         return list;
     };
@@ -1434,7 +1434,7 @@ function Seatchart(seatMap, seatTypes) { // eslint-disable-line no-unused-vars
     var createSmallTitle = function createSmallTitle(content) {
         var smallTitle = document.createElement('h5');
         smallTitle.textContent = content;
-        smallTitle.className = 'seatChart-small-title';
+        smallTitle.className = 'sc-small-title';
 
         return smallTitle;
     };
@@ -1477,7 +1477,7 @@ function Seatchart(seatMap, seatTypes) { // eslint-disable-line no-unused-vars
      */
     var createScItemsContainer = function createScItemsContainer() {
         var container = document.createElement('div');
-        container.className = 'seatChart-sc-items-container';
+        container.className = 'sc-cart-items-container';
 
         return container;
     };
@@ -1546,7 +1546,7 @@ function Seatchart(seatMap, seatTypes) { // eslint-disable-line no-unused-vars
         var container = document.createElement('div');
 
         shoppingCartTotal = createSmallTitle('Total: {0}{1}'.format(self.getTotal(), self.currency));
-        shoppingCartTotal.className += ' seatChart-sc-total';
+        shoppingCartTotal.className += ' sc-cart-total';
 
         var deleteBtn = createScDeleteButton();
         deleteBtn.onclick = deleteAllClick;

--- a/src/js/seatchart.js
+++ b/src/js/seatchart.js
@@ -312,6 +312,13 @@ function Seatchart(seatMap, seatTypes) { // eslint-disable-line no-unused-vars
     var cartTotal;
 
     /**
+     * Text that show total number of items in the shopping cart.
+     * @type {HTMLHeadingElement}
+     * @private
+     */
+    var cartItemsCounter;
+
+    /**
      * A dictionary containing all seats added to the shopping cart, mapped by seat type.
      * Each string is composed by row (r) and column (c) indexed in the following format: "r_c",
      * which is the id of the seat in the document.
@@ -495,12 +502,16 @@ function Seatchart(seatMap, seatTypes) { // eslint-disable-line no-unused-vars
     };
 
     /**
-     * Updates the total price of the shopping cart.
+     * Updates the total price and items counter in the shopping cart.
      * @private
      */
     var updateTotal = function updateTotal() {
         if (cartTotal !== undefined) {
             cartTotal.textContent = 'Total: {0}{1}'.format(self.currency, self.getTotal().toFixed(2));
+        }
+
+        if (cartItemsCounter !== undefined) {
+            cartItemsCounter.textContent = '({0})'.format(cartTable.childNodes.length);
         }
     };
 
@@ -947,12 +958,16 @@ function Seatchart(seatMap, seatTypes) { // eslint-disable-line no-unused-vars
      * @private
      */
     var loadCartItems = function loadCartItems() {
+        var count = 0;
+
         for (var i = 0; i < seatTypes.length; i += 1) {
             var seatType = seatTypes[i];
 
             if ({}.hasOwnProperty.call(seatType, 'selected') && seatType.selected) {
                 var type = seatType.type;
                 var price = seatType.price;
+
+                count += seatType.selected.length;
 
                 for (var j = 0; j < seatType.selected.length; j += 1) {
                     var index = seatType.selected[j];
@@ -971,6 +986,8 @@ function Seatchart(seatMap, seatTypes) { // eslint-disable-line no-unused-vars
                 }
             }
         }
+
+        return count;
     };
 
     /**
@@ -1557,6 +1574,18 @@ function Seatchart(seatMap, seatTypes) { // eslint-disable-line no-unused-vars
     };
 
     /**
+     * Creates text that contains total number of items in the shopping cart.
+     * @returns {HTMLDivElement} The total and "delete all" button.
+     * @private
+     */
+    var createCartItemsCounter = function createCartItemsCounter(count) {
+        var cartItemsCount = document.createElement('h3');
+        cartItemsCount.textContent = '({0})'.format(count);
+
+        return cartItemsCount;
+    };
+
+    /**
      * Creates the total of the shopping cart and a "delete all" button.
      * @returns {HTMLDivElement} The total and "delete all" button.
      * @private
@@ -1601,8 +1630,11 @@ function Seatchart(seatMap, seatTypes) { // eslint-disable-line no-unused-vars
         cartTable = createCartTable();
         cartTableContainer.appendChild(cartTable);
 
-        loadCartItems();
+        var itemsCount = loadCartItems();
         var cartTotal = createCartTotal();
+
+        cartItemsCounter = createCartItemsCounter(itemsCount);
+        cartTitle.appendChild(cartItemsCounter);
 
         cartContainer.appendChild(cartTitle);
         cartContainer.appendChild(cartTableContainer);

--- a/src/js/seatchart.js
+++ b/src/js/seatchart.js
@@ -207,14 +207,14 @@ function Seatchart(seatMap, seatTypes) { // eslint-disable-line no-unused-vars
      * @type {number}
      * @private
      */
-    self.shoppingCartWidth = 200;
+    self.cartWidth = 200;
 
     /**
      * The shopping cart height.
      * @type {number}
      * @private
      */
-    self.shoppingCartHeight = 200;
+    self.cartHeight = 200;
 
     /**
      * An object containing all seats added to the shopping cart, mapped by seat type.
@@ -223,7 +223,7 @@ function Seatchart(seatMap, seatTypes) { // eslint-disable-line no-unused-vars
      * @type {Object.<string, Array.<int>>}
      * @private
      */
-    var shoppingCart = {};
+    var cart = {};
 
     /**
      * Sets the current currency.
@@ -269,11 +269,11 @@ function Seatchart(seatMap, seatTypes) { // eslint-disable-line no-unused-vars
      * Sets the shopping cart width.
      * @param {number} value - The shopping cart width.
      */
-    this.setShoppingCartWidth = function setShoppingCartWidth(value) {
+    this.setCartWidth = function setCartWidth(value) {
         if (typeof value === 'number' && value >= 0) {
-            self.shoppingCartWidth = value;
+            self.cartWidth = value;
         } else {
-            throw new Error("Invalid parameter 'value' supplied to SeatchartJS.setShoppingCartWidth(). " +
+            throw new Error("Invalid parameter 'value' supplied to SeatchartJS.setCartWidth(). " +
                             'Must be positive number.');
         }
     };
@@ -282,19 +282,19 @@ function Seatchart(seatMap, seatTypes) { // eslint-disable-line no-unused-vars
      * Gets the shopping cart width.
      * @returns {number} The shopping cart width.
      */
-    this.getShoppingCartWidth = function getShoppingCartWidth() {
-        return self.shoppingCartWidth;
+    this.getCartWidth = function getCartWidth() {
+        return self.cartWidth;
     };
 
     /**
      * Sets the shopping cart height.
      * @param {number} value - The shopping cart height.
      */
-    this.setShoppingCartHeight = function setShoppingCartHeight(value) {
+    this.setCartHeight = function setCartHeight(value) {
         if (typeof value === 'number' && value >= 0) {
-            self.shoppingCartHeight = value;
+            self.cartHeight = value;
         } else {
-            throw new Error("Invalid parameter 'value' supplied to SeatchartJS.setShoppingCartHeight(). " +
+            throw new Error("Invalid parameter 'value' supplied to SeatchartJS.setCartHeight(). " +
                             'Must be positive number.');
         }
     };
@@ -303,16 +303,16 @@ function Seatchart(seatMap, seatTypes) { // eslint-disable-line no-unused-vars
      * Gets the shopping cart height.
      * @returns {number} The shopping cart height.
      */
-    this.getShoppingCartHeight = function getShoppingCartHeight() {
-        return self.shoppingCartHeight;
+    this.getCartHeight = function getCartHeight() {
+        return self.cartHeight;
     };
 
     /**
     * Gets a reference to the shopping cart object.
     * @returns {Object.<string, Array.<int>>} An object containing all seats added to the shopping cart, mapped by seat type.
     */
-    this.getShoppingCart = function getShoppingCart() {
-        return shoppingCart;
+    this.getCart = function getCart() {
+        return cart;
     };
 
     /**
@@ -334,14 +334,14 @@ function Seatchart(seatMap, seatTypes) { // eslint-disable-line no-unused-vars
      * @type {HTMLDivElement}
      * @private
      */
-    var scItemsContainer;
+    var cartTable;
 
     /**
      * The text that shows the total cost of the items in the shopping cart.
      * @type {HTMLHeadingElement}
      * @private
      */
-    var shoppingCartTotal;
+    var cartTotal;
 
     /**
      * A dictionary containing all seats added to the shopping cart, mapped by seat type.
@@ -350,7 +350,7 @@ function Seatchart(seatMap, seatTypes) { // eslint-disable-line no-unused-vars
      * @type {Object.<string, Array.<string>>}
      * @private
      */
-    var shoppingCartDict = {};
+    var cartDict = {};
 
     /**
      * Adds a seat to the shopping cart dictionary.
@@ -359,10 +359,10 @@ function Seatchart(seatMap, seatTypes) { // eslint-disable-line no-unused-vars
      * @returns {boolean} True if the seat is added correctly otherwise false.
      * @private
      */
-    var addToScDict = function addToScDict(id, type) {
-        if (type in shoppingCartDict) {
-            if ({}.hasOwnProperty.call(shoppingCartDict, type)) {
-                shoppingCartDict[type].push(id);
+    var addToCartDict = function addToCartDict(id, type) {
+        if (type in cartDict) {
+            if ({}.hasOwnProperty.call(cartDict, type)) {
+                cartDict[type].push(id);
                 return true;
             }
         }
@@ -379,11 +379,11 @@ function Seatchart(seatMap, seatTypes) { // eslint-disable-line no-unused-vars
     var initializeSeatTypes = function initializeSeatTypes() {
         // update types of seat
         types = ['available'];
-        shoppingCartDict = [];
+        cartDict = [];
 
         for (var i = 0; i < seatTypes.length; i += 1) {
             types.push(seatTypes[i].type);
-            shoppingCartDict[seatTypes[i].type] = [];
+            cartDict[seatTypes[i].type] = [];
         }
     };
 
@@ -400,23 +400,23 @@ function Seatchart(seatMap, seatTypes) { // eslint-disable-line no-unused-vars
     };
 
     /**
-     * Updates shopping cart object: values stored into shoppingCartDict are mapped to fit
-     * shoppingCart type and format. (See private variables shoppingCartDict and shoppingCart.)
+     * Updates shopping cart object: values stored into cartDict are mapped to fit
+     * cart type and format. (See private variables cartDict and cart.)
      * @private
      */
-    var updateShoppingCartObject = function updateShoppingCartObject() {
-        for (var s in shoppingCartDict) {
-            if ({}.hasOwnProperty.call(shoppingCartDict, s)) {
-                shoppingCart[s] = shoppingCartDict[s].map(getIndexFromId);
+    var updateCartObject = function updateCartObject() {
+        for (var s in cartDict) {
+            if ({}.hasOwnProperty.call(cartDict, s)) {
+                cart[s] = cartDict[s].map(getIndexFromId);
             }
         }
     };
 
     /**
-     * Loads seats into shoppingCartDict.
+     * Loads seats into cartDict.
      * @private
      */
-    var preloadShoppingCart = function preloadShoppingCart() {
+    var loadCart = function loadCart() {
         // create array of seat types
         initializeSeatTypes();
 
@@ -431,15 +431,15 @@ function Seatchart(seatMap, seatTypes) { // eslint-disable-line no-unused-vars
                     var index = seatType.selected[l];
                     var id = '{0}_{1}'.format(Math.floor(index / seatMap.cols), index % seatMap.cols);
                     // add to shopping cart
-                    addToScDict(id, type);
+                    addToCartDict(id, type);
                 }
             }
         }
 
-        updateShoppingCartObject();
+        updateCartObject();
     };
 
-    preloadShoppingCart();
+    loadCart();
 
     /**
      * Create a delete button for a shopping cart item.
@@ -474,16 +474,16 @@ function Seatchart(seatMap, seatTypes) { // eslint-disable-line no-unused-vars
      * @private
      */
     var getSeatType = function getSeatType(id) {
-        for (var key in shoppingCartDict) {
-            if ({}.hasOwnProperty.call(shoppingCartDict, key)) {
-                if (shoppingCartDict[key].indexOf(id) >= 0) {
+        for (var key in cartDict) {
+            if ({}.hasOwnProperty.call(cartDict, key)) {
+                if (cartDict[key].indexOf(id) >= 0) {
                     return key;
                 }
             }
         }
 
         throw new Error("Invalid parameter 'id' supplied to SeatchartJS.getSeatType(). " +
-                        "'id' is not defined in shoppingCartDict.");
+                        "'id' is not defined in cartDict.");
     };
 
     /**
@@ -504,19 +504,19 @@ function Seatchart(seatMap, seatTypes) { // eslint-disable-line no-unused-vars
      * @returns {boolean} True if the seat is removed correctly otherwise false.
      * @private
      */
-    var removeFromScDict = function removeFromScDict(id, type) {
+    var removeFromCartDict = function removeFromCartDict(id, type) {
         if (type !== undefined) {
-            if (type in shoppingCartDict) {
-                var index = shoppingCartDict[type].indexOf(id);
+            if (type in cartDict) {
+                var index = cartDict[type].indexOf(id);
                 if (index > -1) {
-                    shoppingCartDict[type].splice(index, 1);
+                    cartDict[type].splice(index, 1);
                     return true;
                 }
             }
         } else {
-            for (var key in shoppingCartDict) {
-                if ({}.hasOwnProperty.call(shoppingCartDict, key)) {
-                    if (removeFromScDict(id, key)) {
+            for (var key in cartDict) {
+                if ({}.hasOwnProperty.call(cartDict, key)) {
+                    if (removeFromCartDict(id, key)) {
                         return true;
                     }
                 }
@@ -531,8 +531,8 @@ function Seatchart(seatMap, seatTypes) { // eslint-disable-line no-unused-vars
      * @private
      */
     var updateTotal = function updateTotal() {
-        if (shoppingCartTotal !== undefined) {
-            shoppingCartTotal.textContent = 'Total: {0}{1}'.format(self.getTotal(), self.currency);
+        if (cartTotal !== undefined) {
+            cartTotal.textContent = 'Total: {0}{1}'.format(self.getTotal(), self.currency);
         }
     };
 
@@ -548,7 +548,7 @@ function Seatchart(seatMap, seatTypes) { // eslint-disable-line no-unused-vars
         var type = getSeatType(id);
 
         releaseSeat(id);
-        removeFromScDict(id);
+        removeFromCartDict(id);
         updateTotal();
 
         // fire event
@@ -582,11 +582,11 @@ function Seatchart(seatMap, seatTypes) { // eslint-disable-line no-unused-vars
      * @returns {HTMLDivElement} The shopping cart item.
      * @private
      */
-    var createScItem = function createScItem(description, id) {
+    var createCartItem = function createCartItem(description, id) {
         var item = document.createElement('div');
         item.className = 'sc-cart-item';
         // -2 because of the item left padding
-        item.style.width = '{0}px'.format(self.shoppingCartWidth - getScrollBarWidth() - 2);
+        item.style.width = '{0}px'.format(self.cartWidth - getScrollBarWidth() - 2);
         item.setAttribute('id', 'item-{0}'.format(id));
 
         var desc = document.createElement('p');
@@ -611,7 +611,7 @@ function Seatchart(seatMap, seatTypes) { // eslint-disable-line no-unused-vars
      * @param {boolean} emit - True to trigger onChange events.
      * @private
      */
-    var updateShoppingCart = function updateShoppingCart(action, id, type, previousType, emit) {
+    var updateCart = function updateCart(action, id, type, previousType, emit) {
         var seatName = getSeatName(id);
         var index = getIndexFromId(id);
         var price = ['available', 'disabled', 'reserved'].indexOf(type) < 0 ? self.getPrice(type) : null;
@@ -634,10 +634,10 @@ function Seatchart(seatMap, seatTypes) { // eslint-disable-line no-unused-vars
         var scItem;
         var description = '{0} - {1} {2}{3}\n'.format(seatName, type.capitalizeFirstLetter(), self.currency, price);
 
-        updateShoppingCartObject();
+        updateCartObject();
 
         if (action === 'remove') {
-            if (scItemsContainer !== undefined) {
+            if (cartTable !== undefined) {
                 document.getElementById('item-{0}'.format(id)).outerHTML = '';
             }
 
@@ -645,9 +645,9 @@ function Seatchart(seatMap, seatTypes) { // eslint-disable-line no-unused-vars
                 self.onChange(action, current, previous);
             }
         } else if (action === 'add') {
-            if (scItemsContainer !== undefined) {
-                scItem = createScItem(description, id);
-                scItemsContainer.appendChild(scItem);
+            if (cartTable !== undefined) {
+                scItem = createCartItem(description, id);
+                cartTable.appendChild(scItem);
             }
 
             if (emit && self.onChange !== null) {
@@ -756,16 +756,16 @@ function Seatchart(seatMap, seatTypes) { // eslint-disable-line no-unused-vars
                     // this has to be done after updating the shopping cart
                     // so the event is fired just once the seat style is really updated
                     if (currentClass === 'available') {
-                        if (addToScDict(this.id, newClass)) {
-                            updateShoppingCart('add', this.id, newClass, currentClass, true);
+                        if (addToCartDict(this.id, newClass)) {
+                            updateCart('add', this.id, newClass, currentClass, true);
                         }
                     } else if (newClass === 'available') {
-                        if (removeFromScDict(this.id, currentClass)) {
-                            updateShoppingCart('remove', this.id, newClass, currentClass, true);
+                        if (removeFromCartDict(this.id, currentClass)) {
+                            updateCart('remove', this.id, newClass, currentClass, true);
                         }
-                    } else if (addToScDict(this.id, newClass) &&
-                                removeFromScDict(this.id, currentClass)) {
-                        updateShoppingCart('update', this.id, newClass, currentClass, true);
+                    } else if (addToCartDict(this.id, newClass) &&
+                                removeFromCartDict(this.id, currentClass)) {
+                        updateCart('update', this.id, newClass, currentClass, true);
                     }
                 }
             }
@@ -787,11 +787,11 @@ function Seatchart(seatMap, seatTypes) { // eslint-disable-line no-unused-vars
         if (type !== undefined) {
             releaseSeat(this.id);
             // remove from virtual sc
-            removeFromScDict(this.id, type);
+            removeFromCartDict(this.id, type);
 
             // there's no need to fire onChange event since this function fires
             // the event after removing the seat from shopping cart
-            updateShoppingCart('remove', this.id, 'available', type, true);
+            updateCart('remove', this.id, 'available', type, true);
             updateTotal();
         }
 
@@ -947,8 +947,8 @@ function Seatchart(seatMap, seatTypes) { // eslint-disable-line no-unused-vars
                     var capitalizedType = type.capitalizeFirstLetter();
                     var description = '{0} - {1} {2}{3}\n'.format(seatName, capitalizedType, self.currency, price);
 
-                    var scItem = createScItem(description, id);
-                    scItemsContainer.appendChild(scItem);
+                    var scItem = createCartItem(description, id);
+                    cartTable.appendChild(scItem);
                 }
             }
         }
@@ -1005,9 +1005,9 @@ function Seatchart(seatMap, seatTypes) { // eslint-disable-line no-unused-vars
      */
     this.getTotal = function getTotal() {
         var total = 0;
-        for (var key in shoppingCartDict) {
-            if ({}.hasOwnProperty.call(shoppingCartDict, key)) {
-                total += self.getPrice(key) * shoppingCartDict[key].length;
+        for (var key in cartDict) {
+            if ({}.hasOwnProperty.call(cartDict, key)) {
+                total += self.getPrice(key) * cartDict[key].length;
             }
         }
 
@@ -1041,9 +1041,9 @@ function Seatchart(seatMap, seatTypes) { // eslint-disable-line no-unused-vars
         }
 
         // if current seat is selected do not continue
-        for (var key in shoppingCartDict) {
-            if ({}.hasOwnProperty.call(shoppingCartDict, key)) {
-                if (shoppingCartDict[key].indexOf(seatId) >= 0) {
+        for (var key in cartDict) {
+            if ({}.hasOwnProperty.call(cartDict, key)) {
+                if (cartDict[key].indexOf(seatId) >= 0) {
                     return false;
                 }
             }
@@ -1083,14 +1083,14 @@ function Seatchart(seatMap, seatTypes) { // eslint-disable-line no-unused-vars
         var isSeatAfterSelected = false;
 
         // check if seat before and after are selected
-        for (var type in shoppingCartDict) {
-            if ({}.hasOwnProperty.call(shoppingCartDict, type)) {
+        for (var type in cartDict) {
+            if ({}.hasOwnProperty.call(cartDict, type)) {
                 if (!isSeatBeforeSelected) {
-                    isSeatBeforeSelected = shoppingCartDict[type].indexOf(seatBeforeId) >= 0;
+                    isSeatBeforeSelected = cartDict[type].indexOf(seatBeforeId) >= 0;
                 }
 
                 if (!isSeatAfterSelected) {
-                    isSeatAfterSelected = shoppingCartDict[type].indexOf(seatAfterId) >= 0;
+                    isSeatAfterSelected = cartDict[type].indexOf(seatAfterId) >= 0;
                 }
 
                 if (isSeatAfterSelected && isSeatBeforeSelected) {
@@ -1196,10 +1196,10 @@ function Seatchart(seatMap, seatTypes) { // eslint-disable-line no-unused-vars
             }
 
             // check if seat is already selected
-            for (var type in shoppingCartDict) {
-                if ({}.hasOwnProperty.call(shoppingCartDict, type)) {
+            for (var type in cartDict) {
+                if ({}.hasOwnProperty.call(cartDict, type)) {
                     var price = this.getPrice(type);
-                    if (shoppingCartDict[type].indexOf(seatId) >= 0) {
+                    if (cartDict[type].indexOf(seatId) >= 0) {
                         return {
                             type: type,
                             id: seatId,
@@ -1272,21 +1272,21 @@ function Seatchart(seatMap, seatTypes) { // eslint-disable-line no-unused-vars
 
         if (seat.type !== 'available' && seat.type !== 'disabled' && seat.type !== 'reserved') {
             if (type !== 'available' && type !== 'disabled' && type !== 'reserved') {
-                if (removeFromScDict(seat.id, seat.type) && addToScDict(seat.id, type)) {
+                if (removeFromCartDict(seat.id, seat.type) && addToCartDict(seat.id, type)) {
                     element.classList.add('clicked');
                     element.style.setProperty('background-color', seatType.color);
-                    updateShoppingCart('update', seat.id, type, seat.type, emit);
+                    updateCart('update', seat.id, type, seat.type, emit);
                 }
-            } else if (removeFromScDict(seat.id, seat.type)) {
+            } else if (removeFromCartDict(seat.id, seat.type)) {
                 element.classList.remove('clicked');
                 element.style.removeProperty('background-color');
-                updateShoppingCart('remove', seat.id, type, seat.type, emit);
+                updateCart('remove', seat.id, type, seat.type, emit);
             }
         } else if (type !== 'available' && type !== 'disabled' && type !== 'reserved') {
-            if (addToScDict(seat.id, type)) {
+            if (addToCartDict(seat.id, type)) {
                 element.classList.add('clicked');
                 element.style.setProperty('background-color', seatType.color);
-                updateShoppingCart('add', seat.id, type, seat.type, emit);
+                updateCart('add', seat.id, type, seat.type, emit);
             }
         }
 
@@ -1475,7 +1475,7 @@ function Seatchart(seatMap, seatTypes) { // eslint-disable-line no-unused-vars
      * @returns {HTMLDivElement} The container of the items.
      * @private
      */
-    var createScItemsContainer = function createScItemsContainer() {
+    var createCartItemsContainer = function createCartItemsContainer() {
         var container = document.createElement('div');
         container.className = 'sc-cart-items-container';
 
@@ -1490,10 +1490,10 @@ function Seatchart(seatMap, seatTypes) { // eslint-disable-line no-unused-vars
         var removedSeats = [];
 
         // release all selected seats and remove them from dictionary
-        for (var key in shoppingCartDict) {
-            if ({}.hasOwnProperty.call(shoppingCartDict, key)) {
-                for (var i = 0; i < shoppingCartDict[key].length; i += 1) {
-                    var id = shoppingCartDict[key][i];
+        for (var key in cartDict) {
+            if ({}.hasOwnProperty.call(cartDict, key)) {
+                for (var i = 0; i < cartDict[key].length; i += 1) {
+                    var id = cartDict[key][i];
 
                     releaseSeat(id);
 
@@ -1523,12 +1523,12 @@ function Seatchart(seatMap, seatTypes) { // eslint-disable-line no-unused-vars
                 }
 
                 // empty array, fastest way instead of removing each seat
-                shoppingCartDict[key] = [];
+                cartDict[key] = [];
             }
         }
 
         // empty shopping cart, fastest way instead of removing each item
-        scItemsContainer.innerHTML = '';
+        cartTable.innerHTML = '';
 
         updateTotal();
 
@@ -1542,11 +1542,11 @@ function Seatchart(seatMap, seatTypes) { // eslint-disable-line no-unused-vars
      * @returns {HTMLDivElement} The total and "delete all" button.
      * @private
      */
-    var createScTotal = function createScTotal() {
+    var createCartTotal = function createCartTotal() {
         var container = document.createElement('div');
 
-        shoppingCartTotal = createSmallTitle('Total: {0}{1}'.format(self.currency, self.getTotal()));
-        shoppingCartTotal.className += ' sc-cart-total';
+        cartTotal = createSmallTitle('Total: {0}{1}'.format(self.currency, self.getTotal()));
+        cartTotal.className += ' sc-cart-total';
 
         var deleteBtn = createScDeleteButton();
         deleteBtn.onclick = deleteAllClick;
@@ -1556,7 +1556,7 @@ function Seatchart(seatMap, seatTypes) { // eslint-disable-line no-unused-vars
         label.textContent = 'All';
         deleteBtn.appendChild(label);
 
-        container.appendChild(shoppingCartTotal);
+        container.appendChild(cartTotal);
         container.appendChild(deleteBtn);
 
         return container;
@@ -1566,26 +1566,26 @@ function Seatchart(seatMap, seatTypes) { // eslint-disable-line no-unused-vars
      * Creates the shopping cart.
      * @private
      */
-    this.createShoppingCart = function createShoppingCart(containerId) {
-        var shoppingCartContainer = createContainer();
-        var shoppingCartTitle = createIconedTitle(
+    this.createCart = function createCart(containerId) {
+        var cartContainer = createContainer();
+        var cartTitle = createIconedTitle(
             'Your Cart',
             '{0}/icons/shoppingcart.svg'.format(self.assetsSrc),
             'Shopping cart icon.'
         );
 
-        scItemsContainer = createScItemsContainer();
-        scItemsContainer.style.width = '{0}px'.format(self.shoppingCartWidth);
-        scItemsContainer.style.height = '{0}px'.format(self.shoppingCartHeight);
+        cartTable = createCartItemsContainer();
+        cartTable.style.width = '{0}px'.format(self.cartWidth);
+        cartTable.style.height = '{0}px'.format(self.cartHeight);
 
         preloadScItems();
-        var scTotal = createScTotal();
+        var cartTotal = createCartTotal();
 
-        shoppingCartContainer.appendChild(shoppingCartTitle);
-        shoppingCartContainer.appendChild(scItemsContainer);
-        shoppingCartContainer.appendChild(scTotal);
+        cartContainer.appendChild(cartTitle);
+        cartContainer.appendChild(cartTable);
+        cartContainer.appendChild(cartTotal);
 
         var container = document.getElementById(containerId);
-        container.appendChild(shoppingCartContainer);
+        container.appendChild(cartContainer);
     };
 }


### PR DESCRIPTION
### Cart

- Cart layout has improved and the content is arranged into a table
- Now each row contains a ticket like item along with pricing and a delete button
- Total number of items into the cart is display on top
- Currency is now displayed before price value which has two fixed decimals

Before:

![cart](https://user-images.githubusercontent.com/3227034/59713032-bd061280-920e-11e9-8b08-6cd62733a6cb.png)

Now:

![cart](https://user-images.githubusercontent.com/3227034/59711849-33eddc00-920c-11e9-8eb9-ddbdc924de7d.png)

### Other

- Added `backgroundColor` property to `seatTypes` config. `color` is now optional and it does not set the background color of the seats anymore. Instead, along with `backgroundColor`, it sets the respective css property. These properties are applied to the tickets into the cart as well.

```
var types = [
   { type: "regular", backgroundColor: "white", color: "orange", price: 10, selected: [23, 24] },
    // ...
];
```

- Decreased seatchart front size
- Removed check on config colors
- Set default font to Arial
- Updated layout and content of example01
- Css refactoring and minor improvements
